### PR TITLE
AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.

### DIFF
--- a/pcurvepy2/pcurve.py
+++ b/pcurvepy2/pcurve.py
@@ -197,7 +197,7 @@ class PrincipalCurve:
         if self.pseudotimes_interp is None:
             self.project_to_curve(X, points=initial_points)
 
-        d_sq_old = np.Inf
+        d_sq_old = np.inf
 
         for i in range(0, max_iter):
             # 1. Use pseudotimes (s_interp) to order the data and


### PR DESCRIPTION
This pull request includes a small change to the `pcurvepy2/pcurve.py` file. The change corrects the assignment of the variable `d_sq_old` to use `np.inf` instead of `np.Inf`.

* [`pcurvepy2/pcurve.py`](diffhunk://#diff-54642bcb41af60dc679ab3d6d2a37e9d9a178270e79ce78351320da51d2d4436L200-R200): Corrected the assignment of `d_sq_old` to use `np.inf` instead of `np.Inf` in the `fit` method.`np.Inf` to `np.inf` allows the package to work again.